### PR TITLE
Adds ability to add middlewares from config itself

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "saineshmamgain/artisan-gui",
+    "name": "infureal/artisan-gui",
     "type": "library",
     "description": "Beautiful package for [laravel:artisan] gui for cool kids.",
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "infureal/artisan-gui",
+    "name": "saineshmamgain/artisan-gui",
     "type": "library",
     "description": "Beautiful package for [laravel:artisan] gui for cool kids.",
     "license": "MIT",

--- a/config/artisan-gui.php
+++ b/config/artisan-gui.php
@@ -2,8 +2,11 @@
 
 return [
 
-    // Show commands only when authenticated
-    'auth' => true,
+    // Add middlewares to the route
+    'middlewares' => [
+        'web',
+//        'auth'
+    ],
 
     // route prefix -> ~artisan
     'prefix' => '~',

--- a/src/Providers/GuiServiceProvider.php
+++ b/src/Providers/GuiServiceProvider.php
@@ -41,7 +41,7 @@ class GuiServiceProvider extends ServiceProvider  {
     public function register()
     {
         $this->mergeConfigFrom(
-            __DIR__ . "{$this->root}/config/artisan-gui.php", 'artisan-gui'
+            "{$this->root}/config/artisan-gui.php", 'artisan-gui'
         );
     }
 

--- a/src/Providers/GuiServiceProvider.php
+++ b/src/Providers/GuiServiceProvider.php
@@ -38,7 +38,14 @@ class GuiServiceProvider extends ServiceProvider  {
             });
     }
 
-    function boot() {
+    public function register()
+    {
+        $this->mergeConfigFrom(
+            __DIR__ . "{$this->root}/config/artisan-gui.php", 'artisan-gui'
+        );
+    }
+
+    public function boot() {
 
         $local = $this->app->environment('local');
         $only = config('artisan-gui.only_local', true);

--- a/src/Providers/GuiServiceProvider.php
+++ b/src/Providers/GuiServiceProvider.php
@@ -26,10 +26,8 @@ class GuiServiceProvider extends ServiceProvider  {
     }
 
     protected function createRoutes() {
-        $middleware = ['web'];
 
-        if (config('artisan-gui.auth', false))
-            $middleware[] = 'auth';
+        $middleware = config('artisan-gui.middlewares');
 
         \Route::middleware($middleware)
             ->prefix(config('artisan-gui.prefix', '~') . 'artisan')


### PR DESCRIPTION
This pull request adds an ability to add middleware from config itself.
This ability opens a lot of abilities like adding some role/permission middleware to the route so it can be accessed only by user
having certain permissions/role.