### PR TITLE
Added ANSI colors parsing to command output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1828,6 +1828,12 @@
         "color-convert": "^1.9.0"
       }
     },
+    "ansicolor": {
+      "version": "1.1.93",
+      "resolved": "https://registry.npmjs.org/ansicolor/-/ansicolor-1.1.93.tgz",
+      "integrity": "sha512-4dhht0A3T3i+wshSm1kUnJySJnMfaV9Y4O27PcIVQkQR73ska32ddhxxJBIgs+ghvDOs5wpLthiA88VM9SyzPw==",
+      "dev": true
+    },
     "anymatch": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "ansicolor": "^1.1.93",
     "axios": "^0.21.1",
     "browser-sync": "^2.26.13",
     "browser-sync-webpack-plugin": "^2.2.2",

--- a/resources/js/components/CommandOutput.vue
+++ b/resources/js/components/CommandOutput.vue
@@ -11,14 +11,28 @@
       Status: {{ status }}
     </div>
 
-    <div v-html="output">
+    <div v-html="styledOutput">
     </div>
   </div>
 
 </template>
 
 <script>
+import { parse } from 'ansicolor';
+
 export default {
-  props: ['command', 'status', 'output']
+  props: ['command', 'status', 'output'],
+  computed: {
+    styledOutput() {
+      const { spans } = parse(this.output);
+
+      let styled = ''
+      for (let span of spans) {
+        styled += `<span style="${span.css}">${span.text}</span>`
+      }
+
+      return styled
+    }
+  }
 }
 </script>

--- a/src/Http/Controllers/GuiController.php
+++ b/src/Http/Controllers/GuiController.php
@@ -50,7 +50,7 @@ class GuiController extends Controller {
             $params[$key] = $value;
         }
 
-        $output = new BufferedOutput();
+        $output = new BufferedOutput(BufferedOutput::VERBOSITY_NORMAL, true);
         try {
             $status = Artisan::call($command->getName(), $params, $output);
             $output = $output->fetch();


### PR DESCRIPTION
Usage of `$this->info(...)`, `$this->warn(...)` and `$this->error(...)` in commands produces different colors in terminal, which are invisible in GUI.

ANSI color sequences parsing was added in this pull request

### Before:

![image](https://user-images.githubusercontent.com/11861208/110399804-27b04f00-807f-11eb-8918-50bf48c65a6b.png)

### After:

![image](https://user-images.githubusercontent.com/11861208/110399902-529aa300-807f-11eb-8b53-c1106ee16754.png)
